### PR TITLE
Potential fix: scans ships in range before attacking. 

### DIFF
--- a/DeepSpace/Controllers/ShipController.cs
+++ b/DeepSpace/Controllers/ShipController.cs
@@ -110,8 +110,12 @@ namespace DeepSpace.Controllers
         [ActionName("Attack")]
         public async Task<string> Attack([FromBody] AttackShipRequest value)
         {
+            var shipsInRange = await this.ShipManager.ScanAsync(value.CommandCode);
+            var defendingShip = await this.ShipManager.GetShipAsync(value.TransponderCode);            
+            if (!shipsInRange.Contains(defendingShip)) return "Attack failed. Ship out of range.";
             await this.ShipManager.AttackShipAsync(value.CommandCode, value.TransponderCode);
             return "Attack Complete";
+
         }        
 
         [HttpPost]


### PR DESCRIPTION
Checks to see if defending ship is in range.

One potential problem I can foresee is in the AttackShipAsync method. 
The position of the defending ship is checked just before the attack takes place:
if (this.UpdateMovements(defendingShip)) // if the defender's position has changed then update it
            {
                await this.ShipDataAccess.UpsertShipAsync(defendingShip);
            }

If the ship moves out of range at this point, should it still be able to be attacked given that it was in range when the command to attack was issued? Or should there be a subsequent scan to check if it's still in range?